### PR TITLE
2764 Updated height for expansion panel header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--   Fixed non-center aligned chevron in <mat-expansion-panel-header>
+-   Fixed non-center aligned chevron in <mat-expansion-panel-header> ([#50](https://github.com/brightlayer-ui/angular-themes/issues/50))
 -   Fixed disabled slider color in `<mat-slider>`.
 
 ### Changed

--- a/_common.scss
+++ b/_common.scss
@@ -29,6 +29,9 @@
     }
     .mat-expansion-panel {
         .mat-expansion-panel-header {
+            height: 48px !important;
+            border-radius: 0;
+            padding-left: 16px;
             .mat-expansion-indicator {
                 margin-top: -8px;
             }

--- a/_common.scss
+++ b/_common.scss
@@ -30,8 +30,6 @@
     .mat-expansion-panel {
         .mat-expansion-panel-header {
             height: 48px !important;
-            border-radius: 0;
-            padding-left: 16px;
             .mat-expansion-indicator {
                 margin-top: -8px;
             }

--- a/_common.scss
+++ b/_common.scss
@@ -35,7 +35,6 @@
             }
             &.mat-expanded {
                 .mat-expansion-indicator {
-                    transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
                     margin-top: 4px;
                 }
             }

--- a/_common.scss
+++ b/_common.scss
@@ -29,12 +29,13 @@
     }
     .mat-expansion-panel {
         .mat-expansion-panel-header {
-            height: 48px !important;
             .mat-expansion-indicator {
+                transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
                 margin-top: -8px;
             }
             &.mat-expanded {
                 .mat-expansion-indicator {
+                    transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
                     margin-top: 4px;
                 }
             }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #50 #39

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added height to expansion panel header, so that when it expanded, it should not change the height of the content 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
**Desktop**
<img width="1792" alt="148347590-34a58ebb-4c87-46e3-9bee-0b06ada31a90" src="https://user-images.githubusercontent.com/25982779/148771517-1c91d014-cacc-4176-a906-2d064baded93.png">

**Mobile**
<img width="252" alt="148347610-a8ece376-db4a-45e0-aa37-7863306620fc" src="https://user-images.githubusercontent.com/25982779/148771536-c7146ffe-a276-46ae-ba42-4325876c473c.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start
- Open Surfaces under Material Components
- Scroll down to Accordion
