### PR TITLE
add dark theme changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   Fixed non-center aligned chevron in `<mat-expansion-panel-header>`. ([#50](https://github.com/brightlayer-ui/angular-themes/issues/50))
 -   Fixed disabled slider color in `<mat-slider>`. ([#27](https://github.com/brightlayer-ui/angular-themes/issues/27))
--   Fixed text color of active option in `<mat-select>`. ([#18](https://github.com/brightlayer-ui/angular-themes/issues/18))
+-   Fixed text color of active option in `<mat-select>` for light and dark mode. ([#18](https://github.com/brightlayer-ui/angular-themes/issues/18))
 -   Fixed dark-mode text and icon color in `<mat-toolbar>`. ([#18](https://github.com/brightlayer-ui/angular-themes/issues/59))
 
 ### Changed

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -480,7 +480,7 @@
     // }
     .mat-select-panel {
         .mat-option.mat-selected:not(.mat-option-disabled) {
-            color: map-get($blui-black, 500);
+            color: map-get($foreground, text);
         }
     }
 }

--- a/_blueTheme.scss
+++ b/_blueTheme.scss
@@ -479,10 +479,8 @@
     //     background-color: rgba(map-get($blui-black, 500), .05);
     // }
     .mat-select-panel {
-        &.mat-primary {
-            .mat-option.mat-selected:not(.mat-option-disabled) {
-                color: map-get($blui-black, 500);
-            }
+        .mat-option.mat-selected:not(.mat-option-disabled) {
+            color: map-get($blui-black, 500);
         }
     }
 }

--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -584,4 +584,12 @@
         background-color: unset;
         opacity: 0.5;
     }
+    /* mat-select panel  */
+    .mat-select-panel {
+        &.mat-primary {
+            .mat-option.mat-selected:not(.mat-option-disabled) {
+                color: map-get($blui-black, 50);
+            }
+        }
+    }
 }

--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -586,10 +586,8 @@
     }
     /* mat-select panel  */
     .mat-select-panel {
-        &.mat-primary {
-            .mat-option.mat-selected:not(.mat-option-disabled) {
-                color: map-get($blui-black, 50);
-            }
+        .mat-option.mat-selected:not(.mat-option-disabled) {
+            color: map-get($blui-black, 50);
         }
     }
 }

--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -587,7 +587,7 @@
     /* mat-select panel  */
     .mat-select-panel {
         .mat-option.mat-selected:not(.mat-option-disabled) {
-            color: map-get($blui-black, 50);
+            color: map-get($foreground, text);
         }
     }
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [18](https://github.com/brightlayer-ui/angular-themes/issues/18) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Dark theme color for active option -> Black50 color. 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Before:
<img width="434" alt="Screenshot 2022-01-18 at 8 45 49 PM" src="https://user-images.githubusercontent.com/10433274/149964690-d45130d9-65e0-4cae-89e5-6550cbd4d2c0.png">

After:
<img width="420" alt="Screenshot 2022-01-18 at 8 48 32 PM" src="https://user-images.githubusercontent.com/10433274/149965203-2466d27d-1eed-49f2-8ed2-03fb6b3cad9e.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- http://localhost:4200/material-components/input-components (Select component section).
- for checking warn and accent variant add `color="accent"` / `color="warn"` here https://github.com/brightlayer-ui/angular-showcase-demo/blob/b971500d64e66a63ff7c7b6d3ed7335c6e8ad01a/src/app/pages/mat/inputs/inputs.component.html#L311


