### PR TITLE
Feature/2824 37 change table row height to 52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 -   Changed default font-size of `.mat-tooltip` text to `12px`.([#10](https://github.com/brightlayer-ui/angular-themes/issues/10))
+-   Changed default height of `.mat-row` to `52px`.([#37](https://github.com/brightlayer-ui/angular-themes/issues/37))
 
 ## v6.3.0 (November 3, 2021)
 

--- a/_common.scss
+++ b/_common.scss
@@ -43,4 +43,8 @@
     .mat-tooltip {
         font-size: 12px;
     }
+
+    .mat-row {
+        height: 52px;
+    }
 }

--- a/_common.scss
+++ b/_common.scss
@@ -43,8 +43,8 @@
     .mat-tooltip {
         font-size: 12px;
     }
-
     .mat-row {
-        height: 52px;
+        height: unset;
+        min-height: 52px;
     }
 }

--- a/_common.scss
+++ b/_common.scss
@@ -45,6 +45,10 @@
     }
     .mat-row {
         min-height: 3.25rem;
-        padding: 8px 1rem;
+    }
+    td.mat-cell {
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+        font-size: 0.875rem;
     }
 }

--- a/_common.scss
+++ b/_common.scss
@@ -44,7 +44,7 @@
         font-size: 12px;
     }
     .mat-row {
-        height: unset;
-        min-height: 52px;
+        min-height: 3.25rem;
+        padding: 8px 1rem;
     }
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #37 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Updated height of mat-row to 52px

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="402" alt="Screenshot 2022-01-24 at 4 42 54 PM" src="https://user-images.githubusercontent.com/25982779/150772853-e2b65731-c4aa-4787-93af-0a763715c7c7.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start
- Navigate to data display in MUI components
