### PR TITLE
2826 Added horizontal padding to table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## v6.3.1 (Not yet published)
 
-### Changed
-
--   Changed `mat-table` header styles. ([#36](https://github.com/brightlayer-ui/angular-themes/issues/36))
-
 ### Fixed
 
 -   Fixed non-center aligned chevron in `<mat-expansion-panel-header>`. ([#50](https://github.com/brightlayer-ui/angular-themes/issues/50))
@@ -15,6 +11,8 @@
 
 ### Changed
 
+-   Changed `.mat-cell`, `.mat-header-cell` and `.mat-footer-cell` horizontal padding to `1rem` and vertical padding to `0.5rem`. ([#38](https://github.com/brightlayer-ui/angular-themes/issues/38))
+-   Changed `mat-table` header styles. ([#36](https://github.com/brightlayer-ui/angular-themes/issues/36))
 -   Changed default font-size of `.mat-tooltip` text to `12px`.([#10](https://github.com/brightlayer-ui/angular-themes/issues/10))
 -   Changed default height of `.mat-row` to `52px`.([#37](https://github.com/brightlayer-ui/angular-themes/issues/37))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 -   Updated table styles to match design specifications ([#38](https://github.com/brightlayer-ui/angular-themes/issues/38), [#36](https://github.com/brightlayer-ui/angular-themes/issues/36)).
 -   Changed default font-size of `.mat-tooltip` text to `12px`.([#10](https://github.com/brightlayer-ui/angular-themes/issues/10))
--   Changed default height of `.mat-row` to `52px`.([#37](https://github.com/brightlayer-ui/angular-themes/issues/37))
 
 ## v6.3.0 (November 3, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@
 
 ### Changed
 
--   Changed `.mat-cell`, `.mat-header-cell` and `.mat-footer-cell` horizontal padding to `1rem` and vertical padding to `0.5rem`. ([#38](https://github.com/brightlayer-ui/angular-themes/issues/38))
--   Changed `mat-table` header styles. ([#36](https://github.com/brightlayer-ui/angular-themes/issues/36))
+-   Updated table styles to match design specifications ([#38](https://github.com/brightlayer-ui/angular-themes/issues/38), [#36](https://github.com/brightlayer-ui/angular-themes/issues/36)).
 -   Changed default font-size of `.mat-tooltip` text to `12px`.([#10](https://github.com/brightlayer-ui/angular-themes/issues/10))
 -   Changed default height of `.mat-row` to `52px`.([#37](https://github.com/brightlayer-ui/angular-themes/issues/37))
 

--- a/_common.scss
+++ b/_common.scss
@@ -56,7 +56,7 @@
         font-size: 0.875rem;
     }
     th.mat-header-cell, td.mat-cell, td.mat-footer-cell, th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type {
-        padding-left: 1rem;
-        padding-right: 1rem;
+        padding-left: 16px;
+        padding-right: 16px;
     }
 }

--- a/_common.scss
+++ b/_common.scss
@@ -43,7 +43,6 @@
     .mat-tooltip {
         font-size: 12px;
     }
-
     th.mat-header-cell {
         font-size: 0.875rem;
         font-weight: 600;
@@ -55,5 +54,9 @@
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
         font-size: 0.875rem;
+    }
+    th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
+        padding-left: 1rem;
+        padding-right: 1rem;
     }
 }

--- a/_common.scss
+++ b/_common.scss
@@ -55,7 +55,7 @@
         padding-bottom: 0.5rem;
         font-size: 0.875rem;
     }
-    th.mat-header-cell, td.mat-cell, td.mat-footer-cell, th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type {
+    th.mat-header-cell, td.mat-cell, td.mat-footer-cell, th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type, th.mat-header-cell:last-of-type, td.mat-cell:last-of-type, td.mat-footer-cell:last-of-type {
         padding-left: 16px;
         padding-right: 16px;
     }

--- a/_common.scss
+++ b/_common.scss
@@ -55,7 +55,11 @@
         padding-bottom: 0.5rem;
         font-size: 0.875rem;
     }
-    th.mat-header-cell, td.mat-cell, td.mat-footer-cell, th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type, th.mat-header-cell:last-of-type, td.mat-cell:last-of-type, td.mat-footer-cell:last-of-type {
+    th.mat-header-cell, td.mat-cell, td.mat-footer-cell, 
+    th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type, 
+    th.mat-header-cell:last-of-type, td.mat-cell:last-of-type, td.mat-footer-cell:last-of-type, 
+    [dir=rtl] th.mat-header-cell:first-of-type:not(:only-of-type), [dir=rtl] td.mat-cell:first-of-type:not(:only-of-type), [dir=rtl] td.mat-footer-cell:first-of-type:not(:only-of-type),
+    [dir=rtl] th.mat-header-cell:last-of-type:not(:only-of-type), [dir=rtl] td.mat-cell:last-of-type:not(:only-of-type), [dir=rtl] td.mat-footer-cell:last-of-type:not(:only-of-type) {
         padding-left: 16px;
         padding-right: 16px;
     }

--- a/_common.scss
+++ b/_common.scss
@@ -55,7 +55,7 @@
         padding-bottom: 0.5rem;
         font-size: 0.875rem;
     }
-    th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
+    th.mat-header-cell, td.mat-cell, td.mat-footer-cell, th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type {
         padding-left: 1rem;
         padding-right: 1rem;
     }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #38 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added left and right padding to table cells

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1792" alt="Screenshot 2022-01-27 at 4 17 57 PM" src="https://user-images.githubusercontent.com/25982779/151345067-fc4b6f97-a3a0-4b2b-99a4-e3ac9661fe89.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start
- In Material Components --> Data Display --> Table
- Inspect the table cell


