### PR TITLE
Fix styles for suffix/prefix with icon buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   Added `blui-inline` attribute styles to `mat-button`. ([#31](https://github.com/brightlayer-ui/angular-themes/issues/31))
+-   Added `blui-input` attribute styles to `mat-form-field`.
 -   Added new `outline` and `filled` variant for `<mat-toggle-button>`.([#19](https://github.com/brightlayer-ui/angular-themes/issues/19))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -56,6 +56,40 @@ You can then apply the theme to your application by adding the proper class to y
 
 > If you do not specify a theme class, your application will use the default Material theme.
 
+# Custom Classes and Attributes
+
+Brightlayer UI provides some custom classes and attributes that can be used to further align it with Material Design specifications.
+
+### `blui-inline`
+
+`blui-inline` is an attribute that can be placed on a `mat-button` that applies custom icon-sizing and placement.
+
+#### Usage
+
+```
+<button blui-inline mat-flat-button color="primary">
+    <mat-icon>download</mat-icon>
+    <span>Download</span>
+</button>
+```
+
+### `blui-input`
+
+`blui-input` is an attribute that can be applied to a `mat-form-field` to standardize the height to be `56px`.
+
+#### Usage
+
+```ts
+<mat-form-field blui-input appearance="standard">
+    <input matInput placeholder="Placeholder" />
+    <mat-label>Legacy</mat-label>
+    <mat-hint>Hint</mat-hint>
+    <mat-hint align="end">0/10</mat-hint>
+    <mat-icon matSuffix>info</mat-icon>
+    <mat-icon matPrefix>info</mat-icon>
+</mat-form-field>
+```
+
 ### Updating From Version 5 ~> 6
 
 In version 6, we have migrated from the deprecated `typeface-open-sans` package to `@fontsource/open-sans` (bundled with the Brightlayer UI themes). You'll need to update your Open Sans references in angular.json:

--- a/_common.scss
+++ b/_common.scss
@@ -354,20 +354,17 @@
         &.mat-form-field-appearance-standard,
         &.mat-form-field-appearance-legacy {
             .mat-input-element {
-                margin-bottom: 1.25rem;
+                margin-bottom: 0.75rem;
             }
             &.mat-form-field-should-float .mat-form-field-label {
                 margin-top: 0.25rem;
             }
             &.mat-form-field-should-float .mat-input-element {
-                margin-bottom: 0.5em;
-            }
-            &:not(.mat-form-field-should-float) .mat-form-field-infix {
-                margin-top: -.5rem;
+                margin-bottom: 0.5rem;
             }
             .mat-form-field-suffix,
             .mat-form-field-prefix {
-                margin-bottom: .75rem;
+                margin-bottom: 0rem;
             }
             .mat-form-field-infix {
                 padding: 0.4375rem 0;

--- a/_common.scss
+++ b/_common.scss
@@ -316,7 +316,6 @@
                 margin: 0 -0.5rem;
             }
         }
-        .mat-form-field
 
         .mat-form-field-flex {
             height: 3.5rem;

--- a/_common.scss
+++ b/_common.scss
@@ -211,11 +211,12 @@
 
         .mat-form-field-suffix,
         .mat-form-field-prefix {
-            height: 1.5rem;
-            width: 1.5rem;
             .mat-icon {
                 height: 1.5rem;
                 width: 1.5rem;
+            }
+            .mat-button-base {
+                margin: 0 -0.5rem;
             }
         }
 
@@ -311,7 +312,11 @@
                 height: 1.5rem;
                 width: 1.5rem;
             }
+            .mat-button-base {
+                margin: 0 -0.5rem;
+            }
         }
+        .mat-form-field
 
         .mat-form-field-flex {
             height: 3.5rem;

--- a/_common.scss
+++ b/_common.scss
@@ -180,10 +180,12 @@
     [dir='rtl'] .mat-button-base[blui-inline] .mat-icon {
         margin: 0 -4px 0 8px;
     }
+
+
     $ltrOutlinePadding: 0 12px 0 16px;
     $rtlOutlinePadding: 0 16px 0 12px;
     [dir='rtl'] {
-        .mat-form-field:not([blui-condensed]) {
+        .mat-form-field:not([blui-input]) {
             .mat-form-field-prefix {
                 margin-right: 0px;
                 margin-left: 8px;
@@ -204,7 +206,16 @@
             }
         }
     }
-    .mat-form-field:not([blui-condensed]) {
+
+    .mat-form-field-appearance-legacy {
+        .mat-form-field-prefix, .mat-form-field-suffix {
+            .mat-icon-button {
+                font-size: 1.5rem;
+            }
+        }
+    }
+
+    .mat-form-field:not([blui-input]) {
         .mat-form-field-prefix {
             margin-right: 8px;
         }
@@ -216,7 +227,10 @@
                 width: 1.5rem;
             }
             .mat-button-base {
-                margin: 0 -0.5rem;
+                margin: 0.25rem -0.5rem 0 -0.5rem;
+                .mat-icon {
+                    line-height: 1.5rem;
+                }
             }
         }
 
@@ -282,7 +296,7 @@
     $ltrOutlinePadding: 0 12px 0 16px;
     $rtlOutlinePadding: 0 16px 0 12px;
     [dir='rtl'] {
-        .mat-form-field[blui-condensed] {
+        .mat-form-field[blui-input] {
             .mat-form-field-prefix {
                 margin-right: 0px;
                 margin-left: 8px;
@@ -303,7 +317,7 @@
             }
         }
     }
-    .mat-form-field[blui-condensed] {
+    .mat-form-field[blui-input] {
         transition: margin 125ms;
 
         .mat-form-field-suffix,
@@ -313,7 +327,10 @@
                 width: 1.5rem;
             }
             .mat-button-base {
-                margin: 0 -0.5rem;
+                margin: 0.25rem -0.5rem 0 -0.5rem;
+                .mat-icon {
+                    line-height: 1.5rem;
+                }
             }
         }
 
@@ -405,6 +422,4 @@
             margin-top: 0.25rem;
         }
     }
-
-
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.4.0",
+    "version": "6.4.0-beta.2",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Adjust the styles so that `matSuffix` `matPrefix` can support icon buttons.


<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/6538289/153333849-2c8a2deb-964c-4e60-9bd7-7ea674583080.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- The deployed demo has a new example in each input variant that supports icon buttons.
- https://pxb-angular-theme-demo.web.app/material-components/input-components
