### PR TITLE
Fix blui-inline to work with prefix and postfix icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v6.4.1 (Not yet published)
+
+### Fixed
+
+-   Fixed bug where `blui-inline` didn't align buttons with prefix and postfix icons. ([#94](https://github.com/brightlayer-ui/angular-themes/issues/94))
+
 ## v6.4.0 (February 11, 2022)
 
 ### Added

--- a/_common.scss
+++ b/_common.scss
@@ -166,24 +166,31 @@
         padding-right: 16px;
     }
     .mat-button-base[blui-inline] {
+        padding: 0 16px;
         .mat-button-wrapper {
             display: flex;
             align-items: center;
-        }
-        .mat-icon:first-of-type, .mat-icon:last-of-type {
-            height: 1.125rem;
-            width: 1.125rem;
-            font-size: 1.125rem;
-        }
-        .mat-icon:first-of-type {
-            margin: 0 8px 0 -4px;
-        }
-        .mat-icon:last-of-type {
-            margin: 0 -4px 0 8px;
+            justify-content: center;
+            .mat-icon {
+                height: 1.125rem;
+                width: 1.125rem;
+                font-size: 1.125rem;
+            }
+            :first-child.mat-icon {
+                margin: 0 8px 0 -4px;
+            }
+            :last-child.mat-icon {
+                margin: 0 -4px 0 8px;
+            }
         }
     }
-    [dir='rtl'] .mat-button-base[blui-inline] .mat-icon {
-        margin: 0 -4px 0 8px;
+    [dir='rtl'] .mat-button-base[blui-inline] .mat-button-wrapper {
+        :first-child.mat-icon {
+            margin: 0 -4px 0 8px;
+        }
+        :last-child.mat-icon {
+            margin: 0 8px 0 -4px;
+        }
     }
 
 

--- a/_common.scss
+++ b/_common.scss
@@ -170,11 +170,16 @@
             display: flex;
             align-items: center;
         }
-        .mat-icon {
+        .mat-icon:first-of-type, .mat-icon:last-of-type {
             height: 1.125rem;
             width: 1.125rem;
             font-size: 1.125rem;
+        }
+        .mat-icon:first-of-type {
             margin: 0 8px 0 -4px;
+        }
+        .mat-icon:last-of-type {
+            margin: 0 -4px 0 8px;
         }
     }
     [dir='rtl'] .mat-button-base[blui-inline] .mat-icon {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #94 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- This patches the `blui-inline` for the angular-12 version of our themes.

After this is merged in & demoed, I'll do a manual deploy of version 6.4.1.

This uses the same fix in PR #97 
