### PR TITLE
Bug/103 mat button height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 -   Fixed incorrect autocomplete colors for input fields in dark theme ([#76](https://github.com/brightlayer-ui/angular-themes/issues/76)).
-
+-   Fixed default `mat-button` height not being 36px. ([#103](https://github.com/brightlayer-ui/angular-themes/issues/103))
 
 ## v7.0.0 (March 14, 2022)
 

--- a/_common.scss
+++ b/_common.scss
@@ -4,6 +4,11 @@
         line-height: 1.24;
     }
 
+    button.mat-button, a.mat-button {
+        height: 36px;
+        line-height: 36px;
+    }
+
     .mat-chip .mat-chip-avatar.mat-icon {
         height: 18px;
         width: 18px;

--- a/_typography.scss
+++ b/_typography.scss
@@ -94,7 +94,6 @@
         font-size: 0.875rem;
         text-transform: unset;
         line-height: 1.75em;
-        height: 36px;
     }
     .blui-caption,
     .mat-caption {

--- a/_typography.scss
+++ b/_typography.scss
@@ -94,6 +94,7 @@
         font-size: 0.875rem;
         text-transform: unset;
         line-height: 1.75em;
+        height: 36px;
     }
     .blui-caption,
     .mat-caption {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/angular-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "7.0.1-beta.0",
+    "version": "7.0.1-beta.1",
     "description": "Angular themes for Brightlayer UI applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #103 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix the default mat-button height in themes.


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run showcase and observe the default mat-buttons are 36px high.
