### PR TITLE
Adjust filled input bg colors for dark theme

### DIFF
--- a/_darkTheme.scss
+++ b/_darkTheme.scss
@@ -194,7 +194,7 @@
     input:-webkit-autofill:hover,
     input:-webkit-autofill:focus,
     input:-webkit-autofill:active {
-        -webkit-box-shadow: 0 0 0 30px #1e2529 inset !important;
+        -webkit-box-shadow: 0 0 0 30px #333d43 inset !important;
         -webkit-text-fill-color: map-get($foreground, text);
     }
     .mat-form-field-appearance-fill {
@@ -203,7 +203,7 @@
         input:-webkit-autofill:focus,
         input:-webkit-autofill:active {
             //#1e2529
-            -webkit-box-shadow: 0 0 0 30px rgb(37 44 49) inset !important;
+            -webkit-box-shadow: 0 0 0 30px #424e54 inset !important;
         }
     }
 


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- @huayunh During the demo of this story fixing  #105 Joe suggested that the auto-complete input fields not match the default dark theme input bg colors.  


<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
This is what the new autocomplete looks like:
<img width="739" alt="Screen Shot 2022-03-29 at 8 21 36 AM" src="https://user-images.githubusercontent.com/6538289/160610086-41e27ab1-7df7-4c1b-8d0b-5a4505f3d5cc.png">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `yarn start`
