### PR TITLE
fix stepper input style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Fixed default `mat-button` height not being 36px. ([#103](https://github.com/brightlayer-ui/angular-themes/issues/103))
 -   Fixed `mat-expansion-panel-header` border color not similar to divider color ([#107](https://github.com/brightlayer-ui/angular-themes/issues/107))
 -   Fixed `<blui-info-list-item>` disabled state when within a `<mat-nav-list>` ([#114](https://github.com/brightlayer-ui/angular-themes/issues/114))
+-   Fixed stepper input styles ([#90](https://github.com/brightlayer-ui/angular-themes/issues/90))
 
 ## v7.0.0 (March 14, 2022)
 

--- a/_common.scss
+++ b/_common.scss
@@ -4,7 +4,8 @@
         line-height: 1.24;
     }
 
-    button.mat-button, a.mat-button {
+    button.mat-button,
+    a.mat-button {
         height: 36px;
         line-height: 36px;
     }
@@ -265,7 +266,7 @@
                 margin-top: 0.25rem;
             }
             .mat-form-field-infix {
-                margin-top: -1.25rem;
+                margin-top: -1rem;
             }
             .mat-form-field-wrapper {
                 padding-bottom: 1.34375rem;

--- a/_common.scss
+++ b/_common.scss
@@ -266,7 +266,7 @@
                 margin-top: 0.25rem;
             }
             .mat-form-field-infix {
-                margin-top: -1rem;
+                margin-top: -1.25rem;
             }
             .mat-form-field-wrapper {
                 padding-bottom: 1.34375rem;
@@ -308,6 +308,18 @@
 
         .mat-form-field-subscript-wrapper {
             margin-top: 0.25rem;
+        }
+    }
+
+    .mat-stepper-horizontal,
+    .mat-stepper-vertical {
+        .mat-form-field:not([blui-input]) {
+            &.mat-form-field-appearance-standard,
+            &.mat-form-field-appearance-legacy {
+                .mat-form-field-infix {
+                    margin-top: -1rem;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [90](https://github.com/brightlayer-ui/angular-themes/issues/90) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix stepper input style 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="407" alt="Screenshot 2022-05-25 at 3 25 25 PM" src="https://user-images.githubusercontent.com/10433274/170235656-0b17449a-8be0-4fb1-bf97-90aa3836119d.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
Run yarn start
Click on...http://localhost:4200/material-components/navigation-components
stepper card and fill in input fields
